### PR TITLE
enable display of multiple locations per post

### DIFF
--- a/includes/public/cttm-shortcode.php
+++ b/includes/public/cttm-shortcode.php
@@ -245,7 +245,7 @@ function cttm_shortcode($attr)
             // LOOP
             //for each posts get informations:
             //postdatas() is an array of the post thumbnail, url and title
-            //latlngmarkerarr() is an array with only one value, a json array of markers' latitude, longitude and image url(<- or string "default").
+            //latlngmarkerarr() is an array of locations. Each location is a json array of markers' latitude, longitude and image url(<- or string "default").
 
             $cttm_postdatas = array();
             $cttm_postdatas['thumb'] = get_the_post_thumbnail_url($cttm_post->ID, "travelersmap-thumb");
@@ -256,10 +256,12 @@ function cttm_shortcode($attr)
             $latlngmarkerarr = get_post_meta($cttm_post->ID, '_latlngmarker');
 
             //Create the $cttm_metas array to store all the markers and posts informations. This will be send to out javascript file
-            $cttm_metas[$i]['markerdatas'] = $latlngmarkerarr[0];
-            $cttm_metas[$i]['postdatas'] = $cttm_postdatas;
+            foreach ($latlngmarkerarr as $marker) {
+                $cttm_metas[$i]['markerdatas'] = $marker;
+                $cttm_metas[$i]['postdatas'] = $cttm_postdatas;
 
-            $i += 1;
+                $i += 1;
+            } // End foreach $latlngmarkerarr
         } //End foreach
 
     } else {


### PR DESCRIPTION
This pull request is intended as a discussion rather than a complete feature I expect you to accept.

My blog posts have multiple points of interest. I want to display all of them in the overview map. This branch adds the ability to display multiple markers for a single post in the `[travelers-map]` short code. I don't know how to do the front end work to make so people can add multiple locations in the admin page. It will probably involve `add_post_meta` with unique=false, and then `update_post_meta` for the user to update just one of the locations.

I realize that one of the features of the travelers-map plugin is that it is simple, so you may not wish to add this complexity. I did not find any other plugins with support for multiple geo-tag locations for a post. 

For myself, I use the wp-gpx-maps plugin to insert GPS tracks into my posts. I plan to write a function to extract key locations from the GPS tracks and insert them into the post meta table in the format `[travelers-map]` expects.

Thanks for considering my idea,
Emilie