### PR TITLE
Refactor how cttm_options are send from PHP to JS

### DIFF
--- a/includes/public/cttm-shortcode.php
+++ b/includes/public/cttm-shortcode.php
@@ -1,333 +1,359 @@
 <?php
 // Exit if accessed directly
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 /**
  * Display leaflet map shortcode
  */
-add_shortcode('travelersmap', 'cttm_shortcode');
-add_shortcode('travelers-map', 'cttm_shortcode');
+class ctmm_shortcode {
+	/**
+	 * Stores multiple shortcode options for the current page
+	 *
+	 * @var array
+	 */
+	private $shortcode_options = array();
 
-function cttm_shortcode($attr)
-{
+	/**
+	 * ctmm_shortcode constructor.
+	 *
+	 * We add our various actions and shortcode callbacks here when the class is initialized:
+	 */
+	public function __construct() {
+		add_shortcode( 'travelersmap', array( $this, 'render_shortcode' ) );
+		add_shortcode( 'travelers-map', array( $this, 'render_shortcode' ) );
+		add_action( 'wp_footer', array( $this, 'load_scripts_and_styles' ) );
+	}
 
-    //enqueue styles and scripts when shortcode is used
-    wp_enqueue_style('leaflet_css');
-    wp_enqueue_style('travelersmap_css');
-    wp_enqueue_style('leaflet_markerclustercss');
+	/**
+	 * Load our scripts and styles only once, during the "wp_footer" callback.
+	 * This is so multiple calls to [travelersmap] can happen on the page and we collect all their
+	 * configuration and do a single wp_localize_script only once.
+	 */
+	public function load_scripts_and_styles() {
+		// If we haven't loaded any shortcodes by the time we reach the footer, don't bother rendering any scripts or settings:
+		if ( ! count( $this->shortcode_options ) ) {
+			return;
+		}
 
-    wp_enqueue_script('leaflet');
-    wp_enqueue_script('leaflet_markercluster');
-    wp_enqueue_script('travelersmap_init');
+		//Get post types selected in plugin settings
+		$cttm_options = get_option( 'cttm_options' );
+		$searchfield  = $cttm_options['search_field'];
+		$fullscreen   = $cttm_options['fullscreen_button'];
 
-    //Get post types selected in plugin settings
-    $cttm_options = get_option('cttm_options');
-    $settings_posttypes = $cttm_options['posttypes'];
-    $searchfield = $cttm_options['search_field'];
-    $fullscreen = $cttm_options['fullscreen_button'];
+		// Send Json variables to our javascript file 'travelersmap.js'
+		wp_localize_script( 'travelersmap_init', 'cttm_options_params', array(
+			'cttm_options'    => $cttm_options,
+			'cttm_shortcodes' => $this->shortcode_options,
+		) );
 
-    if ($searchfield) {
-        wp_enqueue_script('leaflet_search');
-        wp_enqueue_style('leaflet_search_css');
-    }
-    if ($fullscreen) {
-        wp_enqueue_script('leaflet_fullscreen');
-        wp_enqueue_style('leaflet_fullscreen_css');
-    }
+		// Enqueue styles and scripts when shortcode is used
+		wp_enqueue_style( 'leaflet_css' );
+		wp_enqueue_style( 'travelersmap_css' );
+		wp_enqueue_style( 'leaflet_markerclustercss' );
 
-    /**
-     * Define attributes and their defaults, return only supported attributes
-     * Extract all values to independant variables
-     */
+		wp_enqueue_script( 'leaflet' );
+		wp_enqueue_script( 'leaflet_markercluster' );
+		wp_enqueue_script( 'travelersmap_init' );
 
-    extract(shortcode_atts(array(
-        'height' => '600px',
-        'width' => '100%',
-        "maxwidth" => '',
-        "maxheight" => '',
-        'cats' => '', //by slug, separated by a comma when multiple categories
-        'tags' => '', // by slug, separated by a comma when multiple tags
-        'custom_tax' => '', // (Format 'taxonomy-slug=value1,value2&taxonomy-slug2=value1'). key=value separated by '&' when multiple custom taxonomies. Values separated by comma.
-        'post_types' => $settings_posttypes, // by slug, separated by a comma when multiple posttypes
-        'minzoom' => '',
-        'maxzoom' => '',
-        'this_post' => false,
-        'current_query_markers' => false,
-        'centered_on_this' => false,
-        'init_maxzoom' => 16,
-        'post_id' => false,
-        'open_link_in_new_tab' => false,
-        'disable_clustering' => false,
-        'max_cluster_radius' => 45,
-        'tileurl' => false,
-        'subdomains' => false,
-        'attribution' => false,
-    ), $attr));
 
-    //If attribution is set, require HTMLPurifier and sanitize it
-    if ($attribution !== false) {
-        require_once plugin_dir_path(__DIR__) . '/admin/HTMLPurifier/HTMLPurifier.auto.php';
-        $config = HTMLPurifier_Config::createDefault();
-        $purifier = new HTMLPurifier($config);
-        $attribution = $purifier->purify($attribution);
-    }
+		if ( $searchfield ) {
+			wp_enqueue_script( 'leaflet_search' );
+			wp_enqueue_style( 'leaflet_search_css' );
+		}
+		if ( $fullscreen ) {
+			wp_enqueue_script( 'leaflet_fullscreen' );
+			wp_enqueue_style( 'leaflet_fullscreen_css' );
+		}
+	}
 
-    /**
-     * Custom post taxonomy filtering, defining tax_query accordingly.
-     */
-    //If filtering is set in shortcode
+	public function render_shortcode( $attr ) {
+		//Get post types selected in plugin settings
+		$cttm_options       = get_option( 'cttm_options' );
+		$settings_posttypes = $cttm_options['posttypes'];
 
-    if (!empty($custom_tax)) {
+		/**
+		 * Define attributes and their defaults, return only supported attributes
+		 * Extract all values to independant variables
+		 */
 
-        //Cleaning our string first from space and '&' HTML name code.
-        $custom_tax = str_replace(' ', '', $custom_tax);
-        $custom_tax = str_replace("&amp;", "&", $custom_tax);
-        //Then we extract all the informations and transform into arrays
-        $custom_tax_strings_array = explode('&', $custom_tax);
-        //Define our final array for the query
-        $custom_tax_query_array = array();
-        //For each custom taxonomy array: extract, convert and push to our query array
-        foreach ($custom_tax_strings_array as $custom_tax_strings) {
-            //Get key (our taxonomy slug)
-            $temp_key = substr($custom_tax_strings, 0, strpos($custom_tax_strings, "="));
-            //Get our values (taxonomy terms) as a string
-            $temp_values_string = substr($custom_tax_strings, strpos($custom_tax_strings, "=") + 1);
-            //Convert this string as an array of values
-            $temp_values_array = explode(',', $temp_values_string);
-            //Create our query array
-            $temp_query_array = array('taxonomy' => $temp_key, 'field' => 'slug', 'terms' => $temp_values_array);
-            //Push this array into our final query array
-            $custom_tax_query_array[] = $temp_query_array;
-        }
-        //Create our tax_query array
-        $tax_query = array(
-            'relation' => 'AND',
-            array(
-                'taxonomy' => 'cttm-markers-tax',
-                'terms' => 'hasmarker',
-            ),
-        );
+		extract( shortcode_atts( array(
+			'height'                => '600px',
+			'width'                 => '100%',
+			"maxwidth"              => '',
+			"maxheight"             => '',
+			'cats'                  => '',
+			//by slug, separated by a comma when multiple categories
+			'tags'                  => '',
+			// by slug, separated by a comma when multiple tags
+			'custom_tax'            => '',
+			// (Format 'taxonomy-slug=value1,value2&taxonomy-slug2=value1'). key=value separated by '&' when multiple custom taxonomies. Values separated by comma.
+			'post_types'            => $settings_posttypes,
+			// by slug, separated by a comma when multiple posttypes
+			'minzoom'               => '',
+			'maxzoom'               => '',
+			'this_post'             => false,
+			'current_query_markers' => false,
+			'centered_on_this'      => false,
+			'init_maxzoom'          => 16,
+			'post_id'               => false,
+			'open_link_in_new_tab'  => false,
+			'disable_clustering'    => false,
+			'max_cluster_radius'    => 45,
+			'tileurl'               => false,
+			'subdomains'            => false,
+			'attribution'           => false,
+		), $attr ) );
 
-        //If we have only one custom taxonomy filter, add our custom tax query array directly into the tax_query array.
-        if (count($custom_tax_strings_array) == 1) {
-            $tax_query[] = $custom_tax_query_array[0];
-        }
-        //Else if we have multiple custom taxonomy filters, add them to an outer array with "relation" key, then push into the tax_query array.
-        else if (count($custom_tax_strings_array) > 1) {
-            $tax_multiple_query_array = array('relation' => 'AND', $custom_tax_query_array);
-            $tax_query[] = $tax_multiple_query_array;
-        }
-    } else {
-        //If filtering is not set, set tax_query to only get our private taxonomy cttm-markers-tax
-        $tax_query = array(
-            array(
-                'taxonomy' => 'cttm-markers-tax',
-                'terms' => 'hasmarker',
-            ),
-        );
-    }
+		//If attribution is set, require HTMLPurifier and sanitize it
+		if ( $attribution !== false ) {
+			require_once plugin_dir_path( __DIR__ ) . '/admin/HTMLPurifier/HTMLPurifier.auto.php';
+			$config      = HTMLPurifier_Config::createDefault();
+			$purifier    = new HTMLPurifier( $config );
+			$attribution = $purifier->purify( $attribution );
+		}
 
-    /**
-     * Transform post types string to array
-     */
-    $post_types = explode(',', $post_types);
+		/**
+		 * Custom post taxonomy filtering, defining tax_query accordingly.
+		 */
+		//If filtering is set in shortcode
 
-    /**
-     * Define ID to use in our query
-     */
-    //If a custom ID is set in the shortcode, set it as $current_id
+		if ( ! empty( $custom_tax ) ) {
 
-    if (is_numeric($post_id)) {
+			//Cleaning our string first from space and '&' HTML name code.
+			$custom_tax = str_replace( ' ', '', $custom_tax );
+			$custom_tax = str_replace( "&amp;", "&", $custom_tax );
+			//Then we extract all the informations and transform into arrays
+			$custom_tax_strings_array = explode( '&', $custom_tax );
+			//Define our final array for the query
+			$custom_tax_query_array = array();
+			//For each custom taxonomy array: extract, convert and push to our query array
+			foreach ( $custom_tax_strings_array as $custom_tax_strings ) {
+				//Get key (our taxonomy slug)
+				$temp_key = substr( $custom_tax_strings, 0, strpos( $custom_tax_strings, "=" ) );
+				//Get our values (taxonomy terms) as a string
+				$temp_values_string = substr( $custom_tax_strings, strpos( $custom_tax_strings, "=" ) + 1 );
+				//Convert this string as an array of values
+				$temp_values_array = explode( ',', $temp_values_string );
+				//Create our query array
+				$temp_query_array = array( 'taxonomy' => $temp_key, 'field' => 'slug', 'terms' => $temp_values_array );
+				//Push this array into our final query array
+				$custom_tax_query_array[] = $temp_query_array;
+			}
+			//Create our tax_query array
+			$tax_query = array(
+				'relation' => 'AND',
+				array(
+					'taxonomy' => 'cttm-markers-tax',
+					'terms'    => 'hasmarker',
+				),
+			);
 
-        $current_id = $post_id;
-    } // Else, if the current post has to be shown, or centered on, set its ID as $current_id
-    elseif ($this_post == true || $centered_on_this == true) {
+			//If we have only one custom taxonomy filter, add our custom tax query array directly into the tax_query array.
+			if ( count( $custom_tax_strings_array ) == 1 ) {
+				$tax_query[] = $custom_tax_query_array[0];
+			} //Else if we have multiple custom taxonomy filters, add them to an outer array with "relation" key, then push into the tax_query array.
+			else if ( count( $custom_tax_strings_array ) > 1 ) {
+				$tax_multiple_query_array = array( 'relation' => 'AND', $custom_tax_query_array );
+				$tax_query[]              = $tax_multiple_query_array;
+			}
+		} else {
+			//If filtering is not set, set tax_query to only get our private taxonomy cttm-markers-tax
+			$tax_query = array(
+				array(
+					'taxonomy' => 'cttm-markers-tax',
+					'terms'    => 'hasmarker',
+				),
+			);
+		}
 
-        global $post;
-        $current_id = $post->ID;
-    } // Else, set $current_id to false.
-    else {
+		/**
+		 * Transform post types string to array
+		 */
+		$post_types = explode( ',', $post_types );
 
-        $current_id = false;
-    }
+		/**
+		 * Define ID to use in our query
+		 */
+		//If a custom ID is set in the shortcode, set it as $current_id
 
-    /**
-     * Define query parameters based on shortcode attributes.
-     * current_query_markers has priority over the other attributes and override them.
-     */
-    if ($current_query_markers == true) {
-        global $wp_query;
-        $cttm_global_query_args = $wp_query->query_vars;
-        $cttm_options_args = array_replace($cttm_global_query_args, array(
-            'nopaging' => true,
-            'tax_query' => array(
-                array(
-                    'taxonomy' => 'cttm-markers-tax',
-                    'terms' => 'hasmarker',
-                ),
-            ),
+		if ( is_numeric( $post_id ) ) {
 
-        ));
-    } else {
-        // IF '$current_id' has an ID (see above), we define WP_Query parameters to only get this post/page.
-        if ($current_id) {
+			$current_id = $post_id;
+		} // Else, if the current post has to be shown, or centered on, set its ID as $current_id
+		elseif ( $this_post == true || $centered_on_this == true ) {
 
-            $cttm_options_args = array(
-                'post__in' => array($current_id),
-                'post_type' => 'any',
-                'tax_query' => array(
-                    array(
-                        'taxonomy' => 'cttm-markers-tax',
-                        'terms' => 'hasmarker',
-                    ),
-                ),
-            );
-        } else {
+			global $post;
+			$current_id = $post->ID;
+		} // Else, set $current_id to false.
+		else {
 
-            $cttm_options_args = array(
-                'post_type' => $post_types,
-                'posts_per_page' => -1,
-                'tax_query' => $tax_query,
-                'tag' => $tags,
-                'category_name' => $cats,
-            );
-        }
-    }
+			$current_id = false;
+		}
 
-    /**
-     * Queries depending on shortcode parameters.
-     */
+		/**
+		 * Define query parameters based on shortcode attributes.
+		 * current_query_markers has priority over the other attributes and override them.
+		 */
+		if ( $current_query_markers == true ) {
+			global $wp_query;
+			$cttm_global_query_args = $wp_query->query_vars;
+			$cttm_options_args      = array_replace( $cttm_global_query_args, array(
+				'nopaging'  => true,
+				'tax_query' => array(
+					array(
+						'taxonomy' => 'cttm-markers-tax',
+						'terms'    => 'hasmarker',
+					),
+				),
 
-    // If "centered on this" is set, we get two different queries, to be sure to include current post, even if the other arguments are not including current post:
-    //   The first is our actual post to zoom on
-    //   Second is our general query excluding current post
-    //   Then we merge both into $cttm_query.
-    if ($centered_on_this == true && $this_post == false && $current_query_markers != true) {
-        //Get the single post to zoom on.
-        $cttm_query_singlepost = new WP_Query($cttm_options_args);
+			) );
+		} else {
+			// IF '$current_id' has an ID (see above), we define WP_Query parameters to only get this post/page.
+			if ( $current_id ) {
 
-        wp_reset_query();
-        // We define the query arguments for the other posts, excluding $current_id
-        $cttm_options_args_otherposts = array(
-            'post_type' => $post_types,
-            'post__not_in' => array($current_id),
-            'posts_per_page' => -1,
-            'tax_query' => $tax_query,
-            'tag' => $tags,
-            'category_name' => $cats,
-        );
+				$cttm_options_args = array(
+					'post__in'  => array( $current_id ),
+					'post_type' => 'any',
+					'tax_query' => array(
+						array(
+							'taxonomy' => 'cttm-markers-tax',
+							'terms'    => 'hasmarker',
+						),
+					),
+				);
+			} else {
 
-        //Get the other posts query
-        $cttm_query_otherposts = new WP_Query($cttm_options_args_otherposts);
+				$cttm_options_args = array(
+					'post_type'      => $post_types,
+					'posts_per_page' => - 1,
+					'tax_query'      => $tax_query,
+					'tag'            => $tags,
+					'category_name'  => $cats,
+				);
+			}
+		}
 
-        //We create a new empty query object, and we merge our two previous query inside it.
-        $cttm_query = new WP_Query();
-        $cttm_query->posts = array_merge($cttm_query_singlepost->posts, $cttm_query_otherposts->posts);
-        //Finally, we update post_count to loop inside our new query
-        $cttm_query->post_count = $cttm_query_singlepost->post_count + $cttm_query_otherposts->post_count;
-        wp_reset_query();
-    } else {
-        //If "Centered on this" is not set, query posts with our arguments
-        $cttm_query = new WP_Query($cttm_options_args);
-    }
+		/**
+		 * Queries depending on shortcode parameters.
+		 */
 
-    /**
-     * Loop through our query, save all markers informations and send them to front-end
-     */
-    if (($cttm_query->have_posts())) {
+		// If "centered on this" is set, we get two different queries, to be sure to include current post, even if the other arguments are not including current post:
+		//   The first is our actual post to zoom on
+		//   Second is our general query excluding current post
+		//   Then we merge both into $cttm_query.
+		if ( $centered_on_this == true && $this_post == false && $current_query_markers != true ) {
+			//Get the single post to zoom on.
+			$cttm_query_singlepost = new WP_Query( $cttm_options_args );
 
-        $cttm_posts = $cttm_query->posts;
-        $i = 0;
+			wp_reset_query();
+			// We define the query arguments for the other posts, excluding $current_id
+			$cttm_options_args_otherposts = array(
+				'post_type'      => $post_types,
+				'post__not_in'   => array( $current_id ),
+				'posts_per_page' => - 1,
+				'tax_query'      => $tax_query,
+				'tag'            => $tags,
+				'category_name'  => $cats,
+			);
 
-        foreach ($cttm_posts as $cttm_post) {
-            // LOOP
-            //for each posts get informations:
-            //postdatas() is an array of the post thumbnail, url and title
-            //latlngmarkerarr() is an array with only one value, a json array of markers' latitude, longitude and image url(<- or string "default"), boolean (multiplemarker true/false), custom title string, custom excerpt string, custom thumbnail string
+			//Get the other posts query
+			$cttm_query_otherposts = new WP_Query( $cttm_options_args_otherposts );
 
-            $cttm_postdatas = array();
-            $cttm_postdatas['thumb'] = get_the_post_thumbnail_url($cttm_post->ID, "travelersmap-thumb");
-            $cttm_postdatas['url'] = get_permalink($cttm_post->ID);
-            $cttm_postdatas['thetitle'] = get_the_title($cttm_post->ID);
-            $cttm_postdatas['excerpt'] = get_the_excerpt($cttm_post->ID);
-            $cttm_postdatas['date'] = get_the_date('Y-m-d H:i:s', $cttm_post->ID);
-            $latlngmarkerarr = get_post_meta($cttm_post->ID, '_latlngmarker');
+			//We create a new empty query object, and we merge our two previous query inside it.
+			$cttm_query        = new WP_Query();
+			$cttm_query->posts = array_merge( $cttm_query_singlepost->posts, $cttm_query_otherposts->posts );
+			//Finally, we update post_count to loop inside our new query
+			$cttm_query->post_count = $cttm_query_singlepost->post_count + $cttm_query_otherposts->post_count;
+			wp_reset_query();
+		} else {
+			//If "Centered on this" is not set, query posts with our arguments
+			$cttm_query = new WP_Query( $cttm_options_args );
+		}
 
-            // If a custom thumbnail ID is defined, get the thumbnail url and replace it in the array
-            $latlngmarkerarr_decoded = json_decode($latlngmarkerarr[0], true);
+		/**
+		 * Loop through our query, save all markers informations and send them to front-end
+		 */
+		if ( ( $cttm_query->have_posts() ) ) {
 
-            if (isset($latlngmarkerarr_decoded['customthumbnail'])) {
-                $cttm_thumbnail_id = intval($latlngmarkerarr_decoded['customthumbnail']); // = int: 114
-                $your_img_src = wp_get_attachment_image_src($cttm_thumbnail_id, 'travelersmap-thumb'); //Return false? This is not working, I don't know why.
-                if ($your_img_src != false) {
-                    $latlngmarkerarr_decoded['customthumbnail'] = $your_img_src[0];
-                } else {
-                    $latlngmarkerarr_decoded['customthumbnail'] = "";
-                }
+			$cttm_posts = $cttm_query->posts;
+			$i          = 0;
 
-                $latlngmarkerarr[0] = json_encode($latlngmarkerarr_decoded);
-            }
+			foreach ( $cttm_posts as $cttm_post ) {
+				// LOOP
+				//for each posts get informations:
+				//postdatas() is an array of the post thumbnail, url and title
+				//latlngmarkerarr() is an array with only one value, a json array of markers' latitude, longitude and image url(<- or string "default"), boolean (multiplemarker true/false), custom title string, custom excerpt string, custom thumbnail string
 
-            //Create the $cttm_metas array to store all the markers and posts informations. This will be send to out javascript file
-            $cttm_metas[$i]['markerdatas'] = $latlngmarkerarr[0];
-            $cttm_metas[$i]['postdatas'] = $cttm_postdatas;
+				$cttm_postdatas             = array();
+				$cttm_postdatas['thumb']    = get_the_post_thumbnail_url( $cttm_post->ID, "travelersmap-thumb" );
+				$cttm_postdatas['url']      = get_permalink( $cttm_post->ID );
+				$cttm_postdatas['thetitle'] = get_the_title( $cttm_post->ID );
+				$cttm_postdatas['excerpt']  = get_the_excerpt( $cttm_post->ID );
+				$cttm_postdatas['date']     = get_the_date( 'Y-m-d H:i:s', $cttm_post->ID );
+				$latlngmarkerarr            = get_post_meta( $cttm_post->ID, '_latlngmarker' );
 
-            $i += 1;
-        } //End foreach
+				// If a custom thumbnail ID is defined, get the thumbnail url and replace it in the array
+				$latlngmarkerarr_decoded = json_decode( $latlngmarkerarr[0], true );
 
-    } else {
-        //End If have_posts()
-        $cttm_metas = 0;
-    }
-    //json_encode the array to send it to our javascript
-    //htmlspecialchars to avoid errors with &quot;
-    $cttm_metas = htmlspecialchars(json_encode($cttm_metas));
+				if ( isset( $latlngmarkerarr_decoded['customthumbnail'] ) ) {
+					$cttm_thumbnail_id = intval( $latlngmarkerarr_decoded['customthumbnail'] ); // = int: 114
+					$your_img_src      = wp_get_attachment_image_src( $cttm_thumbnail_id, 'travelersmap-thumb' ); //Return false? This is not working, I don't know why.
+					if ( $your_img_src != false ) {
+						$latlngmarkerarr_decoded['customthumbnail'] = $your_img_src[0];
+					} else {
+						$latlngmarkerarr_decoded['customthumbnail'] = "";
+					}
 
-    //Get global options from the setting page to show the map in front-end
-    //cttm_options is an array
-    $cttm_options_json = htmlspecialchars(json_encode($cttm_options));
+					$latlngmarkerarr[0] = $latlngmarkerarr_decoded;
+				}
 
-    $id = uniqid();
-    $containerid = "travelersmap-container-" . $id;
+				//Create the $cttm_metas array to store all the markers and posts informations. This will be send to out javascript file
+				$cttm_metas[ $i ]['markerdatas'] = $latlngmarkerarr[0];
+				$cttm_metas[ $i ]['postdatas']   = $cttm_postdatas;
 
-    //Create this shortcode options array to send to javascript
-    $cttm_shortcode_options = array();
-    $cttm_shortcode_options['id'] = $id;
-    $cttm_shortcode_options['minzoom'] = $minzoom;
-    $cttm_shortcode_options['maxzoom'] = $maxzoom;
-    $cttm_shortcode_options['this_post'] = (string) $this_post;
-    $cttm_shortcode_options['init_maxzoom'] = $init_maxzoom;
-    $cttm_shortcode_options['centered_on_this'] = (string) $centered_on_this;
-    $cttm_shortcode_options['open_link_in_new_tab'] = (string) $open_link_in_new_tab;
-    $cttm_shortcode_options['disable_clustering'] = (string) $disable_clustering;
-    $cttm_shortcode_options['max_cluster_radius'] = $max_cluster_radius;
-    $cttm_shortcode_options['tileurl'] = (string) $tileurl;
-    $cttm_shortcode_options['subdomains'] = (string) $subdomains;
-    $cttm_shortcode_options['attribution'] = (string) $attribution;
+				$i += 1;
+			} //End foreach
 
-    //Encode to Json
-    $cttm_shortcode_options = json_encode($cttm_shortcode_options);
+		} else {
+			//End If have_posts()
+			$cttm_metas = 0;
+		}
 
-    //Create the array sent to Javascript
-    $cttm_options_params = array(
-        'cttm_options' => $cttm_options_json,
-    );
+		$id          = uniqid();
+		$containerid = "travelersmap-container-" . $id;
 
-    //Create the array with shortcode options
-    ${"cttm_shortcode_$id"} = array(
-        'cttm_metas' => $cttm_metas,
-        'cttm_shortcode_options' => $cttm_shortcode_options,
-    );
+		//Create this shortcode options array to send to javascript
+		$cttm_shortcode_options                         = array();
+		$cttm_shortcode_options['id']                   = $id;
+		$cttm_shortcode_options['minzoom']              = $minzoom;
+		$cttm_shortcode_options['maxzoom']              = $maxzoom;
+		$cttm_shortcode_options['this_post']            = (string) $this_post;
+		$cttm_shortcode_options['init_maxzoom']         = $init_maxzoom;
+		$cttm_shortcode_options['centered_on_this']     = (string) $centered_on_this;
+		$cttm_shortcode_options['open_link_in_new_tab'] = (string) $open_link_in_new_tab;
+		$cttm_shortcode_options['disable_clustering']   = (string) $disable_clustering;
+		$cttm_shortcode_options['max_cluster_radius']   = $max_cluster_radius;
+		$cttm_shortcode_options['tileurl']              = (string) $tileurl;
+		$cttm_shortcode_options['subdomains']           = (string) $subdomains;
+		$cttm_shortcode_options['attribution']          = (string) $attribution;
 
-    //Send Json variables to our javascript file 'travelersmap.js'
-    wp_localize_script('travelersmap_init', 'cttm_options_params', $cttm_options_params);
-    wp_localize_script('travelersmap_init', 'cttm_shortcode_' . $id, ${"cttm_shortcode_$id"});
-    if ($cttm_metas) {
-        $cttm_output =   '<div id="' . $containerid . '" class="travelersmap-container" style="z-index: 1; min-height: 10px; min-width:10px; height:' . $height . ';width:' . $width . '; max-width:' . $maxwidth . '; max-height:' . $maxheight . '; position:relative;"><div style="position:absolute; z-index:-1;top: 50%;text-align: center;display: block;left: 50%;transform: translate(-50%,-50%);">Travelers\' Map is loading... <br> If you see this after your page is loaded completely, leafletJS files are missing.</div></div>';
-    } else {
-        $cttm_output =   '<div id="' . $containerid . '" class="travelersmap-container" style="z-index: 1; min-height: 10px; min-width:10px; height:' . $height . ';width:' . $width . '; max-width:' . $maxwidth . '; max-height:' . $maxheight . '; position:relative;"><div style="position:absolute; z-index:-1;top: 50%;text-align: center;display: block;left: 50%;transform: translate(-50%,-50%);">No markers found for this Travelers\' map. <br> Please add some markers to your posts before using this shortcode.</div></div>';
-    }
-    return $cttm_output;
+		// Append our shortcode options to the global list of options so it can be wp_localize_script
+		$this->shortcode_options[] = [
+			'cttm_metas'             => $cttm_metas,
+			'cttm_shortcode_options' => $cttm_shortcode_options,
+		];
+
+		if ( $cttm_metas ) {
+			$cttm_output = '<div id="' . $containerid . '" class="travelersmap-container" style="z-index: 1; min-height: 10px; min-width:10px; height:' . $height . ';width:' . $width . '; max-width:' . $maxwidth . '; max-height:' . $maxheight . '; position:relative;"><div style="position:absolute; z-index:-1;top: 50%;text-align: center;display: block;left: 50%;transform: translate(-50%,-50%);">Travelers\' Map is loading... <br> If you see this after your page is loaded completely, leafletJS files are missing.</div></div>';
+		} else {
+			$cttm_output = '<div id="' . $containerid . '" class="travelersmap-container" style="z-index: 1; min-height: 10px; min-width:10px; height:' . $height . ';width:' . $width . '; max-width:' . $maxwidth . '; max-height:' . $maxheight . '; position:relative;"><div style="position:absolute; z-index:-1;top: 50%;text-align: center;display: block;left: 50%;transform: translate(-50%,-50%);">No markers found for this Travelers\' map. <br> Please add some markers to your posts before using this shortcode.</div></div>';
+		}
+
+		return $cttm_output;
+	}
 }
+
+
+$cttm_shortcode = new ctmm_shortcode();

--- a/includes/public/js/travelersmap.js
+++ b/includes/public/js/travelersmap.js
@@ -3,7 +3,7 @@ function initTravelersMap() {
    * Get plugin options from database
    */
 
-  //Get plugin options from the database, set in the setting page.
+    //Get plugin options from the database, set in the setting page.
   const cttm_options = cttm_options_params.cttm_options;
   const cttm_shortcodes = cttm_options_params.cttm_shortcodes;
 
@@ -226,68 +226,68 @@ function initTravelersMap() {
         }
       } //END if(markerdatas)
 
-      //add Leaflet.search to the map when option is checked
-      if (cttm_options && cttm_options["search_field"] == 1) {
-        this_cttm_map.addControl(
-          new L.Control.Search({
-            url:
-              "https://nominatim.openstreetmap.org/search?format=json&q={s}",
-            jsonpParam: "json_callback",
-            propertyName: "display_name",
-            propertyLoc: ["lat", "lon"],
-            autoCollapse: false,
-            collapsed: false,
-            autoType: true,
-            minLength: 2,
-            zoom: 13,
-            firstTipSubmit: true,
-            hideMarkerOnCollapse: true,
-          })
-        );
-
-        //On focus, enable zoom with mousewheel on map.
-        document.querySelector("#searchtext9").addEventListener(
-          "focus",
-          function () {
-            this_cttm_map.scrollWheelZoom.enable();
-          },
-          true
-        );
-      }
-
-      //add Leaflet.fullscreen to the map when option is checked
-      if (cttm_options && cttm_options["fullscreen_button"] == 1) {
-        this_cttm_map.addControl(
-          new L.Control.Fullscreen({
-            position: "topright",
-          })
-        );
-      }
-
-      //add markercluster layer to the map
-      this_cttm_map.addLayer(markersGroup);
-
-      //Set the initial view
-      //If centered_on_this is set, set view on this post
-      if (cttm_shortcode_options.centered_on_this == "true") {
-        //get the marker latitude and longitude, the first of our query.
-        let centered_on_marker = cttm_metas[0].markerdatas;
-        let centerlatitude = centered_on_marker.latitude;
-        let centerlongitude = centered_on_marker.longitude;
-
-        this_cttm_map.setView(
-          [centerlatitude, centerlongitude],
-          init_maxzoom
-        );
-      } else {
-        //If centered_on_this is not set, fit the view to see every maker on the map
-        this_cttm_map.fitBounds(markersGroup.getBounds(), {
-          padding: [60, 60],
-          maxZoom: init_maxzoom,
-        });
-      }
-
     } //END loop on cttm_metas
+
+    //add Leaflet.search to the map when option is checked
+    if (cttm_options && cttm_options["search_field"] == 1) {
+      this_cttm_map.addControl(
+        new L.Control.Search({
+          url:
+            "https://nominatim.openstreetmap.org/search?format=json&q={s}",
+          jsonpParam: "json_callback",
+          propertyName: "display_name",
+          propertyLoc: ["lat", "lon"],
+          autoCollapse: false,
+          collapsed: false,
+          autoType: true,
+          minLength: 2,
+          zoom: 13,
+          firstTipSubmit: true,
+          hideMarkerOnCollapse: true,
+        })
+      );
+
+      //On focus, enable zoom with mousewheel on map.
+      document.querySelector("#searchtext9").addEventListener(
+        "focus",
+        function () {
+          this_cttm_map.scrollWheelZoom.enable();
+        },
+        true
+      );
+    }
+
+    //add Leaflet.fullscreen to the map when option is checked
+    if (cttm_options && cttm_options["fullscreen_button"] == 1) {
+      this_cttm_map.addControl(
+        new L.Control.Fullscreen({
+          position: "topright",
+        })
+      );
+    }
+
+    //add markercluster layer to the map
+    this_cttm_map.addLayer(markersGroup);
+
+    //Set the initial view
+    //If centered_on_this is set, set view on this post
+    if (cttm_shortcode_options.centered_on_this == "true") {
+      //get the marker latitude and longitude, the first of our query.
+      let centered_on_marker = cttm_metas[0].markerdatas;
+      let centerlatitude = centered_on_marker.latitude;
+      let centerlongitude = centered_on_marker.longitude;
+
+      this_cttm_map.setView(
+        [centerlatitude, centerlongitude],
+        init_maxzoom
+      );
+    } else {
+      //If centered_on_this is not set, fit the view to see every maker on the map
+      this_cttm_map.fitBounds(markersGroup.getBounds(), {
+        padding: [60, 60],
+        maxZoom: init_maxzoom,
+      });
+    }
 
     //Recalculate map size after 100ms to avoid problems with page builders changing element size on document load.
     //Avoid problem with tiles not loading inside the whole container.

--- a/includes/public/js/travelersmap.js
+++ b/includes/public/js/travelersmap.js
@@ -4,53 +4,29 @@ function initTravelersMap() {
    */
 
   //Get plugin options from the database, set in the setting page.
-  let json_cttm_options = cttm_options_params.cttm_options;
+  const cttm_options = cttm_options_params.cttm_options;
+  const cttm_shortcodes = cttm_options_params.cttm_shortcodes;
 
-  //Retrieve and store all shortcodes data arrays sent by php in "cttm_shortcode_vars_arr"
-  let cttm_shortcode_vars_arr = new Array();
+  // If no shortcode config is defined then we return early
+  if (!cttm_shortcodes) return;
 
-  //Search for every js variable beginning with "cttm_shortcode_"
-  let cttm_varname_pattern = /^cttm_shortcode_/;
-  for (let cttm_varName in window) {
-    if (cttm_varname_pattern.test(cttm_varName)) {
-      cttm_shortcode_vars_arr.push(window[cttm_varName]);
-    }
-  }
-  /**
-   * Loop : Create a new map for each shortcode in the page
-   * Before the loop, initialize global array of map objects and index number
-   */
+  cttm_shortcodes.forEach(cttmMapLoop);
 
-  //Index of map objects in array
-  let mapindex = 0;
-  //Create cttm_map public array of object if not already created
-  if (typeof cttm_map === "undefined") {
-    window.cttm_map = new Array();
-  } else {
-    //if our maps are already initialized, this removes them nicely before initializing them again. Can be used to refresh the maps.
-    for (let i = cttm_map.length - 1; i >= 0; i--) {
-      cttm_map[i].remove();
-      cttm_map.splice(i, 1);
-    }
-  }
-
-  cttm_shortcode_vars_arr.forEach(cttmMapLoop);
-
-  function cttmMapLoop(cttm_shortcode_vars) {
-    //If no markers are loaded, return without initiating leaflet
-    if(cttm_shortcode_vars.cttm_metas == "0"){
+  function cttmMapLoop(shortcode) {
+    if (!shortcode) {
       return;
     }
-    //Get shortcode options
-    let json_cttm_shortcode = cttm_shortcode_vars.cttm_shortcode_options;
+    const cttm_metas = shortcode.cttm_metas
+    const cttm_shortcode_options = shortcode.cttm_shortcode_options
 
-    //Clean json string to be usable
-    json_cttm_options = json_cttm_options.replace(/&quot;/g, '\\"');
-    json_cttm_shortcode = json_cttm_shortcode.replace(/&quot;/g, '\\"');
+    //If no markers are loaded, return without initiating leaflet
+    if (!cttm_metas || cttm_metas.length === 0) {
+      return;
+    }
 
-    //Get arrays of all the options and shortcode options
-    let cttm_options = JSON.parse(json_cttm_options);
-    var cttm_shortcode_options = JSON.parse(json_cttm_shortcode);
+    if (!cttm_shortcode_options) {
+      return;
+    }
 
     /**
      * Create leaflet map options object. This object is then passed as argument when the map initialized.
@@ -64,7 +40,7 @@ function initTravelersMap() {
     ];
 
     // If one-finger touch event is disabled on mobile
-    if (cttm_options["onefinger"]) {
+    if (cttm_options && cttm_options["onefinger"]) {
       cttm_map_options.dragging = !L.Browser.mobile;
       cttm_map_options.tap = !L.Browser.mobile;
     }
@@ -95,46 +71,52 @@ function initTravelersMap() {
      * Create leaflet map object "cttm_map"
      */
 
-    //Get cttm_map container id
+      //Get cttm_map container id
     let containerid = cttm_shortcode_options.id;
     let container = document.getElementById(
       "travelersmap-container-" + containerid
     );
+
+    // Return early if we don't find the element.
+    if (!container) {
+      console.error('Unable to find cttm container on page: ' + containerid);
+      return;
+    }
 
     //Set Tiles Server URL + API key + Attribution
     //If a shortcode tile server is set, override global settings' tile server
     let tileurl, subdomains, attribution;
     if (cttm_shortcode_options.tileurl !== "") {
       tileurl = cttm_shortcode_options.tileurl;
-    } else {
+    } else if (cttm_options) {
       tileurl = cttm_options["tileurl"];
     }
     if (cttm_shortcode_options.subdomains !== "") {
       subdomains = cttm_shortcode_options.subdomains;
-    } else {
+    } else if (cttm_options) {
       subdomains = cttm_options["subdomains"];
     }
     if (cttm_shortcode_options.attribution !== "") {
       attribution = cttm_shortcode_options.attribution;
-    } else {
+    } else if (cttm_options) {
       attribution = cttm_options["attribution"];
     }
 
     //Push current map object to array
-    cttm_map.push(L.map(container, cttm_map_options));
+    let this_cttm_map = L.map(container, cttm_map_options);
     //Get Tiles server URL + API key + Attribution
     L.tileLayer(tileurl, {
       subdomains: subdomains,
       attribution: attribution,
-    }).addTo(cttm_map[mapindex]);
+    }).addTo(this_cttm_map);
 
 
     /**
      * Disable Scrollwheel zoom when map is not in focus
      */
-    cttm_map[mapindex].scrollWheelZoom.disable();
+    this_cttm_map.scrollWheelZoom.disable();
     //Enable Scrollwheel Zoom on focus
-    cttm_map[mapindex].on("focus", function (e) {
+    this_cttm_map.on("focus", function (e) {
       this.scrollWheelZoom.enable();
     });
 
@@ -174,91 +156,79 @@ function initTravelersMap() {
       cttm_options
     );
 
-    //Get markers metas and linked posts datas from shortcode
-    let json_cttm_metas = cttm_shortcode_vars.cttm_metas;
+    //Loop through cttm_metas array, create all the markers and popovers.
+    for (let i = 0; i < cttm_metas.length; i++) {
+      //If current markerdata is not falsy:
+      //Prevent bug with multilingual plugins, where metadatas are synced but not taxonomy:
+      //If one remove a marker from a post, the other languages of this post will still appear in the query...
+      if (cttm_metas[i].markerdatas) {
+        //Get markerdatas object
+        var markerdatas = cttm_metas[i].markerdatas;
 
-    //If posts with markers exist
-    if (json_cttm_metas != 0) {
-      //Clean json string to be usable
-      json_cttm_metas = json_cttm_metas.replace(/&quot;/g, '\\"');
+        //Initialize all markers variables
+        let markerlatitude = markerdatas.latitude;
+        let markerlongitude = markerdatas.longitude;
+        let markerURL = markerdatas.markerdata[0];
+        let markerwidth = markerdatas.markerdata[1];
+        let markerheight = markerdatas.markerdata[2];
 
-      //Get an array of objects containing markerdatas and postdatas
-      cttm_metas = JSON.parse(json_cttm_metas);
+        //Get linked postdatas object
+        let postdatas = cttm_metas[i].postdatas;
 
-      //Loop through cttm_metas array, create all the markers and popovers.
-      for (let i = 0; i < cttm_metas.length; i++) {
-        //If current markerdata is not falsy:
-        //Prevent bug with multilingual plugins, where metadatas are synced but not taxonomy:
-        //If one remove a marker from a post, the other languages of this post will still appear in the query...
-        if (cttm_metas[i].markerdatas) {
-          //Get markerdatas object
-          var markerdatas = JSON.parse(cttm_metas[i].markerdatas);
+        //////////// Use this for V2.
+        //////////// if (markerdatas.multiplemarkers) { }
 
-          //Initialize all markers variables
-          let markerlatitude = markerdatas.latitude;
-          let markerlongitude = markerdatas.longitude;
-          let markerURL = markerdatas.markerdata[0];
-          let markerwidth = markerdatas.markerdata[1];
-          let markerheight = markerdatas.markerdata[2];
+        //Alter postdatas array in case we have custom data set
+        if (markerdatas.customtitle) {
+          postdatas.thetitle = markerdatas.customtitle;
+        }
+        if (markerdatas.customexcerpt) {
+          postdatas.excerpt = markerdatas.customexcerpt;
+        }
+        if (markerdatas.customthumbnail) {
+          postdatas.thumb = markerdatas.customthumbnail;
+        }
 
-          //Get linked postdatas object
-          let postdatas = cttm_metas[i].postdatas;
+        // Create a leaflet icon object and add it to the map, if not set, use default
+        //"d" is returned when no icon is set
+        if (markerURL != "d") {
+          //Create custom icon
+          let myIcon = L.icon({
+            iconUrl: markerURL,
+            iconSize: [markerwidth, markerheight],
+            iconAnchor: [markerwidth / 2, markerheight],
+            popupAnchor: [0, -markerheight + 3],
+          });
+          //Create marker object wih our icon
+          var marker = L.marker([markerlatitude, markerlongitude], {
+            icon: myIcon,
+          });
+        } else {
+          //Create marker object with default icon
+          var marker = L.marker([markerlatitude, markerlongitude]);
+        }
 
-          //////////// Use this for V2.
-          //////////// if (markerdatas.multiplemarkers) { }
+        let postPopoverOutput = cttmPopulatePopoversHTMLOutput(
+          postdatas,
+          popoverOutput,
+          cttm_options
+        );
 
-          //Alter postdatas array in case we have custom data set
-          if (markerdatas.customtitle) {
-            postdatas.thetitle = markerdatas.customtitle;
-          }
-          if (markerdatas.customexcerpt) {
-            postdatas.excerpt = markerdatas.customexcerpt;
-          }
-          if (markerdatas.customthumbnail) {
-            postdatas.thumb = markerdatas.customthumbnail;
-          }
-
-          // Create a leaflet icon object and add it to the map, if not set, use default
-          //"d" is returned when no icon is set
-          if (markerURL != "d") {
-            //Create custom icon
-            let myIcon = L.icon({
-              iconUrl: markerURL,
-              iconSize: [markerwidth, markerheight],
-              iconAnchor: [markerwidth / 2, markerheight],
-              popupAnchor: [0, -markerheight + 3],
-            });
-            //Create marker object wih our icon
-            var marker = L.marker([markerlatitude, markerlongitude], {
-              icon: myIcon,
-            });
-          } else {
-            //Create marker object with default icon
-            var marker = L.marker([markerlatitude, markerlongitude]);
-          }
-
-          let postPopoverOutput = cttmPopulatePopoversHTMLOutput(
-            postdatas,
-            popoverOutput,
-            cttm_options
+        //If "this_post" option is set
+        //Add the marker in our cluster group layer without popover
+        //Else add it with its popover
+        if (cttm_shortcode_options.this_post == "true") {
+          markersGroup.addLayer(marker);
+        } else {
+          markersGroup.addLayer(
+            marker.bindPopup(postPopoverOutput, popoverOptions)
           );
-
-          //If "this_post" option is set
-          //Add the marker in our cluster group layer without popover
-          //Else add it with its popover
-          if (cttm_shortcode_options.this_post == "true") {
-            markersGroup.addLayer(marker);
-          } else {
-            markersGroup.addLayer(
-              marker.bindPopup(postPopoverOutput, popoverOptions)
-            );
-          }
-        } //END if(markerdatas)
-      } //END For Loop through cttm_metas
+        }
+      } //END if(markerdatas)
 
       //add Leaflet.search to the map when option is checked
-      if (cttm_options["search_field"] == 1) {
-        cttm_map[mapindex].addControl(
+      if (cttm_options && cttm_options["search_field"] == 1) {
+        this_cttm_map.addControl(
           new L.Control.Search({
             url:
               "https://nominatim.openstreetmap.org/search?format=json&q={s}",
@@ -279,15 +249,15 @@ function initTravelersMap() {
         document.querySelector("#searchtext9").addEventListener(
           "focus",
           function () {
-            cttm_map[mapindex].scrollWheelZoom.enable();
+            this_cttm_map.scrollWheelZoom.enable();
           },
           true
         );
       }
 
       //add Leaflet.fullscreen to the map when option is checked
-      if (cttm_options["fullscreen_button"] == 1) {
-        cttm_map[mapindex].addControl(
+      if (cttm_options && cttm_options["fullscreen_button"] == 1) {
+        this_cttm_map.addControl(
           new L.Control.Fullscreen({
             position: "topright",
           })
@@ -295,39 +265,37 @@ function initTravelersMap() {
       }
 
       //add markercluster layer to the map
-      cttm_map[mapindex].addLayer(markersGroup);
+      this_cttm_map.addLayer(markersGroup);
 
       //Set the initial view
       //If centered_on_this is set, set view on this post
       if (cttm_shortcode_options.centered_on_this == "true") {
         //get the marker latitude and longitude, the first of our query.
-        let centered_on_marker = JSON.parse(cttm_metas[0].markerdatas);
+        let centered_on_marker = cttm_metas[0].markerdatas;
         let centerlatitude = centered_on_marker.latitude;
         let centerlongitude = centered_on_marker.longitude;
 
-        cttm_map[mapindex].setView(
+        this_cttm_map.setView(
           [centerlatitude, centerlongitude],
           init_maxzoom
         );
       } else {
         //If centered_on_this is not set, fit the view to see every maker on the map
-        cttm_map[mapindex].fitBounds(markersGroup.getBounds(), {
+        this_cttm_map.fitBounds(markersGroup.getBounds(), {
           padding: [60, 60],
           maxZoom: init_maxzoom,
         });
       }
 
-    } //END if (!json_cttm_metas)
+    } //END loop on cttm_metas
 
     //Recalculate map size after 100ms to avoid problems with page builders changing element size on document load.
     //Avoid problem with tiles not loading inside the whole container.
 
-    const mapindexcopy = mapindex;
     setTimeout(() => {
-      cttm_map[mapindexcopy].invalidateSize()
+      this_cttm_map.invalidateSize()
     }, 1000);
 
-    mapindex++;
   } // END FUNCTION cttmMapLoop()
 
   // Create event to listen to know when the maps are loaded and cttm_map array is created
@@ -346,6 +314,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initTravelersMap();
   }
 });
+
 /**
  * Generate unpopulated markers popovers HTML from the options set by the user.
  * The user can choose what to show inside every popover in Travelers' Map setting page.
@@ -366,12 +335,12 @@ function cttmGeneratePopoverHTMLOutput(cttm_shortcode_options, cttm_options) {
     popoverTarget = "_self";
   }
   //Then we create HMTL output for popovers depending of style set in plugin settings
-  let popoverStyles = cttm_options["popup_style"].split(",");
+  let popoverStyles = cttm_options ? cttm_options["popup_style"].split(",") : "";
 
   if (popoverStyles.indexOf("thumbnail") != -1) {
     if (popoverStyles.indexOf("excerpt") != -1) {
       //Detailed Popup : Thumbnail and excerpt, with (title) and (date). () = optionnal
-      popoverOptions = { className: "detailed-popup" };
+      popoverOptions = {className: "detailed-popup"};
       popoverOutput =
         '<a class="tooltip-link" href="%s_url" target="' + popoverTarget + '">';
       popoverOutput += '<div class="nothumbplaceholder"></div>';
@@ -380,7 +349,7 @@ function cttmGeneratePopoverHTMLOutput(cttm_shortcode_options, cttm_options) {
       popoverOutput += '<div class="excerpt">%s_excerpt</div>';
     } else {
       //Default Popup : Thumbnail with (title) and (date). () = optionnal
-      popoverOptions = { className: "default-popup" };
+      popoverOptions = {className: "default-popup"};
 
       popoverOutput = '<div class="img-mask">';
       popoverOutput += '<div class="nothumbplaceholder"></div>';
@@ -395,7 +364,7 @@ function cttmGeneratePopoverHTMLOutput(cttm_shortcode_options, cttm_options) {
     }
   } else {
     //Textual Popup : excerpt, title and date. At least one or more of those.
-    popoverOptions = { className: "textual-popup" };
+    popoverOptions = {className: "textual-popup"};
 
     popoverOutput =
       '<a class="tooltip-link" href="%s_url" target="' + popoverTarget + '">';
@@ -405,11 +374,12 @@ function cttmGeneratePopoverHTMLOutput(cttm_shortcode_options, cttm_options) {
   }
 
   //If css is disabled, change popover class
-  if (cttm_options["popup_css"]) {
-    popoverOptions = { className: "custom-popup" };
+  if (cttm_options && cttm_options["popup_css"]) {
+    popoverOptions = {className: "custom-popup"};
   }
   return [popoverOutput, popoverOptions];
 }
+
 /**
  *
  * Populate markers' popovers HTML output with data sent.
@@ -433,7 +403,7 @@ function cttmPopulatePopoversHTMLOutput(
     month: "long",
     day: "numeric",
   });
-  let popoverStyles = cttm_options["popup_style"].split(",");
+  let popoverStyles = cttm_options ? cttm_options["popup_style"].split(",") : "";
   let postPopoverOutput = popoverOutput;
 
   if (postThumb) {


### PR DESCRIPTION
## Context![image](https://user-images.githubusercontent.com/543073/120758609-63ab6100-c555-11eb-89e2-cec8c3227c0d.png)

There were some issues with page builders firing the [travelersmap] shortcode multiple times on a single page load. This caused some weird JS double up variables like so:

```
 var cttm_options_params = etc..
 var cttm_shortcode_60b9be30c56fe = etc..
 var cttm_options_params = etc..
 var cttm_shortcode_60b9be30cfd2e = etc..
```

## Changes

This refactor solves this by only rendering a single JS variable object like so:


```
 var var cttm_options_params = {"cttm_options":  (options here),  "cttm_shortcodes": [ (array of shortcodes here) ]
```

Now the JS only has a single global variable to inspect and we can remove all that dynamic window. variable stuff.

Also moved the shortcode init PHP into a class constructor as that's my personal preference for easy scope management, especially when trying to share data between multiple WP callbacks (such as the shortcode and wp footer callback).

Also removed a bunch of the JSON encode and decode stuff, as WordPress should handle that for us out of the box and give a correct JSON object for the browser to parse.

## Screenshots (before)

![image](https://user-images.githubusercontent.com/543073/120758544-51c9be00-c555-11eb-8dff-c2aa0ba6aeb8.png)

![image](https://user-images.githubusercontent.com/543073/120758609-63ab6100-c555-11eb-89e2-cec8c3227c0d.png)

## Screenshots (after)


![image](https://user-images.githubusercontent.com/543073/120758921-c43a9e00-c555-11eb-8a67-8055cc092051.png)

![image](https://user-images.githubusercontent.com/543073/120758689-79b92180-c555-11eb-86d6-477533ecbd6a.png)

